### PR TITLE
READMEにBilingual Localizationの紹介を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## これはなに
 日本語訳用の言語ファイルです。 [AUTOMATIC1111版Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui)で使用します。
 
-また、2カ国語の同時表示を可能にする[Bilingual Localization](https://github.com/journey-ad/sd-webui-bilingual-localization)拡張機能との併用がおすすめです。この拡張機能を使えば、日本語環境での利用だけでなく、英語での情報収集も容易になります。
+また、2カ国語の同時表示を可能にする[Bilingual Localization](https://github.com/Katsuyuki-Karasawa/sd-webui-bilingual-localization/blob/main/README_JA.md)拡張機能との併用を推奨します。  
+この拡張機能を使えば、日本語環境での利用だけでなく、英語での情報収集も容易になります。
 
 ## インストール方法
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ## これはなに
 日本語訳用の言語ファイルです。 [AUTOMATIC1111版Stable Diffusion web UI](https://github.com/AUTOMATIC1111/stable-diffusion-webui)で使用します。
 
+また、2カ国語の同時表示を可能にする[Bilingual Localization](https://github.com/journey-ad/sd-webui-bilingual-localization)拡張機能との併用がおすすめです。この拡張機能を使えば、日本語環境での利用だけでなく、英語での情報収集も容易になります。
+
 ## インストール方法
 
 ### 1. 公式の拡張機能リストからインストール(最も推奨)


### PR DESCRIPTION
日本語化を入れることでUIの項目について調べ物をしたりするのが難しくなるというイメージが根強く、ユーザーの間ではあまり日本語化が使われていない（使わないほうが良いとアドバイスされがちな）印象を受けます。

[中国語ローカライズ](https://github.com/dtlnor/stable-diffusion-webui-localization-zh_CN)のリポジトリを見ていると、[UIに二言語を同時表示する拡張機能](https://github.com/journey-ad/sd-webui-bilingual-localization)というものが紹介されていました。
これをユーザーに使ってもらえば上記の問題は解消できますし、たとえばメニューの「txt2img」を「テキストから画像」に翻訳するといった大胆な決定もしやすいかと思います。