### PR TITLE
fix: Disable caching for localization file

### DIFF
--- a/javascript/bilingual_localization.js
+++ b/javascript/bilingual_localization.js
@@ -281,7 +281,10 @@
     // Load file
     function readFile(filePath) {
       let request = new XMLHttpRequest();
-      request.open("GET", `file=${filePath}`, false);
+      request.open('GET', `file=${filePath}`, false);
+      request.setRequestHeader('Pragma', 'no-cache');
+      request.setRequestHeader('Cache-Control', 'no-cache');
+      request.setRequestHeader('If-Modified-Since', 'Thu, 01 Jun 1970 00:00:00 GMT');
       request.send(null);
       return request.responseText;
     }


### PR DESCRIPTION
Dealing with the issue where updated language files were not reflected on the screen due to the browser cache being enabled when loading the language file.